### PR TITLE
fixed logic in isShooterUpToSpeed()

### DIFF
--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -112,7 +112,7 @@ public class Shooter extends SubsystemBase {
 
   public boolean isShooterUpToSpeed() {
     return ShooterPrefs.shooterAcceptableErrorRPM.getValue() > Math
-        .abs(SN_Math.VelocityToRPM(leadMotor.getClosedLoopError(), SN_Math.TALONFX_ENCODER_PULSES_PER_COUNT));
+        .abs(SN_Math.velocityToRPM(leadMotor.getClosedLoopError(), SN_Math.TALONFX_ENCODER_PULSES_PER_COUNT));
 
     // return true if the acceptable error (in rpm) is greater than the actual error
     // (converted to rpm)


### PR DESCRIPTION
method now checks if current shooter RPM error is within allowable range