### PR TITLE
matched preference and variable names

### DIFF
--- a/src/main/java/frc/robot/RobotPreferences.java
+++ b/src/main/java/frc/robot/RobotPreferences.java
@@ -156,8 +156,8 @@ public final class RobotPreferences {
         110);
     public static final SN_DoublePreference turretMinAngleDegrees = new SN_DoublePreference("turretMinAngleDegrees",
         -270);
-    public static final SN_DoublePreference turretSnapAwayIntake = new SN_DoublePreference("turretSnapToIntake", 90);
-    public static final SN_DoublePreference turretSnapToIntake = new SN_DoublePreference("turretSnapAwayIntake", -90);
+    public static final SN_DoublePreference turretSnapAwayIntake = new SN_DoublePreference("turretSnapAwayIntake", 90);
+    public static final SN_DoublePreference turretSnapToIntake = new SN_DoublePreference("turretSnapToIntake", -90);
 
     // 2048 encoder counts per rotation * 65 (gr) = 133120
     // 133120 / 360 = 370


### PR DESCRIPTION
```java
public static final SN_DoublePreference turretSnapAwayIntake = new SN_DoublePreference("turretSnapToIntake", 90);
public static final SN_DoublePreference turretSnapToIntake = new SN_DoublePreference("turretSnapAwayIntake", -90);
```

In #345 in `RobotPreferences.java` lines 159 and 160 were changed to this. Can you spot the error?